### PR TITLE
gitbatch: proper checksum for linux

### DIFF
--- a/gitbatch.rb
+++ b/gitbatch.rb
@@ -7,7 +7,7 @@ class Gitbatch < Formula
 
   if OS.linux? && Hardware::CPU.is_64_bit?
     url "https://github.com/isacikgoz/gitbatch/releases/download/v0.5.0/gitbatch_0.5.0_linux_amd64.tar.gz"
-    sha256 "cadd377e5672281c62b304768110c1a0b36ed752e133d52ae220dedb6d56db69"
+    sha256 "d8bfaa70b128cc3e682c98dd2b127eefe4dc6a52113d5b2531117d8a4f258337"
   end
 
   def install


### PR DESCRIPTION
With current one:
```
➜  ~  brew install gitbatch
==> Installing gitbatch from isacikgoz/taps
==> Downloading https://github.com/isacikgoz/gitbatch/releases/download/v0.5.0/gitbatch_0.5.0_linux_
==> Downloading from https://github-production-release-asset-2e65be.s3.amazonaws.com/157984719/7b87d
######################################################################## 100.0%
Error: An exception occurred within a child process:
  ChecksumMismatchError: SHA256 mismatch
Expected: cadd377e5672281c62b304768110c1a0b36ed752e133d52ae220dedb6d56db69
  Actual: d8bfaa70b128cc3e682c98dd2b127eefe4dc6a52113d5b2531117d8a4f258337
 Archive: /home/dawidd6/.cache/Homebrew/downloads/5b1ab821bf2e8fbd840f107ad6251fdb3a0de863f67479a21a87f173034a9ac7--gitbatch_0.5.0_linux_amd64.tar.gz
To retry an incomplete download, remove the file above.
```

With new one:
```
➜  ~  brew install gitbatch
==> Installing gitbatch from isacikgoz/taps
==> Downloading https://github.com/isacikgoz/gitbatch/releases/download/v0.5.0/gitbatch_0.5.0_linux_amd64.tar.gz
Already downloaded: /home/dawidd6/.cache/Homebrew/downloads/5b1ab821bf2e8fbd840f107ad6251fdb3a0de863f67479a21a87f173034a9ac7--gitbatch_0.5.0_linux_amd64.tar.gz
🍺  /home/linuxbrew/.linuxbrew/Cellar/gitbatch/0.5.0: 3 files, 13.3MB, built in 2 seconds
```